### PR TITLE
feat: Iterate through the subnets(CIDR) in IP ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![GoDoc](https://godoc.org/github.com/iiiceoo/iprange?status.svg)](https://godoc.org/github.com/iiiceoo/iprange)
 [![codecov](https://codecov.io/gh/iiiceoo/iprange/branch/main/graph/badge.svg?token=7STDXD53G0)](https://codecov.io/gh/iiiceoo/iprange)
 
-*The package iprange parses IPv4/IPv6 addresses from strings in IP range format and handles interval mathematics between multiple IP ranges.*
+*The package iprange parses IPv4/IPv6 addresses from strings in IP range format.*
 
-## IP range formats
+## Supported IP range formats
 
 - `172.18.0.1` / `fd00::1`
 - `172.18.0.0/24` / `fd00::/64`
@@ -30,7 +30,7 @@ func main() {
 		"172.18.0.1",
 		"172.18.0.0/24",
 		"172.18.0.1-10",
-		"172.18.0.1-172.18.1.10",
+		"172.18.1.1-172.18.1.3",
 	)
 	if err != nil {
 		log.Fatalf("failed to parse IP ranges: %v\n", err)
@@ -43,18 +43,29 @@ func main() {
 
 	// Interval mathematics of IP ranges.
 	another, _ := iprange.Parse("172.18.0.0/24")
-	diffSet := merged.Diff(another)
-	fmt.Printf("The difference between two IP ranges: %s\n", diffSet)
+	diffRanges := merged.Diff(another)
+	fmt.Printf("The difference between two IP ranges: %s\n", diffRanges)
 
-	// Iterate through IP ranges.
-	fmt.Printf("Scan all %d IP addresses in the set:\n", diffSet.Size())
-	iter := diffSet.Iterator()
+	// Convert IP ranges to IP addresses.
+	fmt.Printf("Iterate through all %d IP addresses:\n", diffRanges.Size())
+	ipIter := diffRanges.IPIterator()
 	for {
-		ip := iter.Next()
+		ip := ipIter.Next()
 		if ip == nil {
 			break
 		}
 		fmt.Println(ip)
+	}
+
+	// Convert IP ranges to subnets.
+	fmt.Println("Iterate through subnets:")
+	cidrIter := diffRanges.CIDRIterator()
+	for {
+		cidr := cidrIter.Next()
+		if cidr == nil {
+			break
+		}
+		fmt.Println(cidr)
 	}
 }
 ```

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 /*
 Package iprange parses IPv4/IPv6 addresses from strings in IP range
-format and handles interval mathematics between multiple IP ranges.
+format.
 
 The following IP range formats are supported:
 
@@ -39,14 +39,23 @@ different IP versions, it won't work:
 
 	res := v4Ranges.Diff(v6Ranges)  // res will be equal to v4Ranges.
 
-The IPRanges can be converted into individual net.IP through its own iterator.
-Continuously call the method Next() to iterate through the IPRanges until
-nil is returned:
+The IPRanges can be converted into multiple net.IP (i.e. IP addresses)
+or *net.IPNet (i.e. subnets) through their own iterators. Continuously
+call the method Next() until nil is returned:
 
-	iter := ranges.Iterator()
+	ipIter := ranges.IPIterator()
 	for {
-		ip := iter.Next()
+		ip := ipIter.Next()
 		if ip == nil {
+			break
+		}
+		// Do someting.
+	}
+
+	cidrIter := ranges.CIDRIterator()
+	for {
+		cidr := cidrIter.Next()
+		if cidr == nil {
 			break
 		}
 		// Do someting.
@@ -54,8 +63,9 @@ nil is returned:
 
 Finally, the inspiration for writing this package comes from
 
-	CNI plugins: https://github.com/containernetworking/plugins
+	CNI plugins:      https://github.com/containernetworking/plugins
 	malfunkt/iprange: https://github.com/malfunkt/iprange
+	netaddr/netaddr:  https://github.com/netaddr/netaddr
 
 both of which are great!
 */

--- a/example_test.go
+++ b/example_test.go
@@ -164,13 +164,13 @@ func ExampleIPRanges_Intersect() {
 	// [172.18.0.5-172.18.0.25]
 }
 
-func ExampleIPRanges_Iterator() {
+func ExampleIPRanges_IPIterator() {
 	ranges, err := iprange.Parse("172.18.0.1-3")
 	if err != nil {
 		log.Fatalf("error parsing IP ranges: %v", err)
 	}
 
-	iter := ranges.Iterator()
+	iter := ranges.IPIterator()
 	for {
 		ip := iter.Next()
 		if ip == nil {
@@ -182,4 +182,24 @@ func ExampleIPRanges_Iterator() {
 	// 172.18.0.1
 	// 172.18.0.2
 	// 172.18.0.3
+}
+
+func ExampleIPRanges_CIDRIterator() {
+	ranges, err := iprange.Parse("172.18.0.0-255", "172.18.0.1-3")
+	if err != nil {
+		log.Fatalf("error parsing IP ranges: %v", err)
+	}
+
+	iter := ranges.CIDRIterator()
+	for {
+		cidr := iter.Next()
+		if cidr == nil {
+			break
+		}
+		fmt.Println(cidr)
+	}
+	// Output:
+	// 172.18.0.0/24
+	// 172.18.0.1/32
+	// 172.18.0.2/31
 }

--- a/ip.go
+++ b/ip.go
@@ -78,3 +78,39 @@ func normalizeIP(ip net.IP) net.IP {
 
 	return ip.To16()
 }
+
+// maxXIP returns the larger xIP between x and y.
+func maxXIP(x, y xIP) xIP {
+	if x.cmp(y) > 0 {
+		return x
+	}
+
+	return y
+}
+
+// minXIP returns the smaller xIP between x and y.
+func minXIP(x, y xIP) xIP {
+	if x.cmp(y) < 0 {
+		return x
+	}
+
+	return y
+}
+
+// max returns the larger of x and y.
+func max(x, y int) int {
+	if x > y {
+		return x
+	}
+
+	return y
+}
+
+// min returns the smaller of x and y.
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+
+	return y
+}

--- a/iterator.go
+++ b/iterator.go
@@ -1,48 +1,134 @@
 package iprange
 
-import "net"
+import (
+	"math/big"
+	"net"
+)
 
-type rangesIterator struct {
+type ipIterator struct {
 	ranges     []ipRange
 	rangeIndex int
 	current    xIP
 }
 
-// Iterator generates a new iterator for IPRanges rr, which stores the merged
-// IP ranges (ordered and deduplicated) and always points the cursor to the
-// first IP address. Call the method Next to iterate through the IPRanges.
-func (rr *IPRanges) Iterator() *rangesIterator {
-	return &rangesIterator{
-		ranges: rr.Merge().ranges,
+// IPIterator generates a new iterator for scanning IP addresses. Call
+// the method Next to get the next IP address.
+func (rr *IPRanges) IPIterator() *ipIterator {
+	return &ipIterator{
+		ranges: rr.ranges,
 	}
 }
 
-// Next returns the next IP address. If the rangesIterator has been exhausted,
+// Next returns the next IP address. If the ipIterator has been exhausted,
 // return nil.
-func (ri *rangesIterator) Next() net.IP {
-	n := len(ri.ranges)
-	// ri.ranges is an empty slice or ri.current equals to the last IP address.
-	if n == ri.rangeIndex {
+func (ii *ipIterator) Next() net.IP {
+	n := len(ii.ranges)
+	if n == 0 {
 		return nil
 	}
 
-	r := ri.ranges[ri.rangeIndex]
-	if ri.current.IP == nil {
-		ri.current.IP = r.start.IP
-		return ri.current.IP
+	if ii.current.IP == nil {
+		ii.current.IP = ii.ranges[0].start.IP
+		return ii.current.IP
 	}
 
-	if !ri.current.Equal(r.end.IP) {
-		ri.current = ri.current.next()
-		return ri.current.IP
+	if !ii.current.Equal(ii.ranges[ii.rangeIndex].end.IP) {
+		ii.current = ii.current.next()
+		return ii.current.IP
 	}
 
-	ri.rangeIndex++
-	if ri.rangeIndex == n {
+	ii.rangeIndex++
+	if ii.rangeIndex == n {
 		return nil
 	}
-	r = ri.ranges[ri.rangeIndex]
-	ri.current = r.start
+	ii.current = ii.ranges[ii.rangeIndex].start
 
-	return ri.current.IP
+	return ii.current.IP
+}
+
+type cidrIterator struct {
+	ranges     []ipRange
+	rangeIndex int
+
+	ipBitLen int
+	lastInt  *big.Int
+	current  *big.Int
+}
+
+// CIDRIterator generates a new iterator for scanning CIDR. Call the
+// method Next to get the next CIDR.
+func (rr *IPRanges) CIDRIterator() *cidrIterator {
+	iter := &cidrIterator{
+		ranges: rr.ranges,
+	}
+
+	if len(iter.ranges) != 0 {
+		r := iter.ranges[0]
+		iter.ipBitLen = len(r.start.IP) * 8
+		iter.lastInt = ipToInt(r.end.IP)
+		iter.current = ipToInt(r.start.IP)
+	}
+
+	return iter
+}
+
+// Next returns the next CIDR. If the cidrIterator has been exhausted,
+// return nil.
+func (ci *cidrIterator) Next() *net.IPNet {
+	n := len(ci.ranges)
+	if n == 0 {
+		return nil
+	}
+
+	if ci.current.Cmp(ci.lastInt) <= 0 {
+		return ci.next()
+	}
+
+	ci.rangeIndex++
+	if ci.rangeIndex == n {
+		return nil
+	}
+	ci.lastInt = ipToInt(ci.ranges[ci.rangeIndex].end.IP)
+	ci.current = ipToInt(ci.ranges[ci.rangeIndex].start.IP)
+
+	return ci.next()
+}
+
+func (ci *cidrIterator) next() *net.IPNet {
+	delta := big.NewInt(0)
+	delta.Sub(ci.lastInt, ci.current)
+	delta.Add(delta, big.NewInt(1))
+
+	curIP := intToIP(ci.current)
+	nbits := min(righthandZeroBits(curIP), delta.BitLen()-1)
+
+	incr := big.NewInt(1)
+	incr.Lsh(incr, uint(nbits))
+	ci.current.Add(ci.current, incr)
+
+	return &net.IPNet{
+		IP:   curIP,
+		Mask: net.CIDRMask(ci.ipBitLen-nbits, ci.ipBitLen),
+	}
+}
+
+// righthandZeroBits counts the number of zero bits on the right hand
+// side of bb.
+func righthandZeroBits(bb []byte) int {
+	n := 0
+	for i := len(bb) - 1; i >= 0; i-- {
+		b := bb[i]
+		if b == 0 {
+			n += 8
+			continue
+		}
+
+		for b&1 == 0 {
+			n++
+			b >>= 1
+		}
+		break
+	}
+
+	return n
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -6,65 +6,63 @@ import (
 	"testing"
 )
 
-var ipRangesIteratorTests = []struct {
+var ipRangesIPIteratorTests = []struct {
 	name   string
 	ranges *IPRanges
 	want   []net.IP
 }{
 	{
-		"Iterate through IPv4 IP ranges",
+		"Iterate through the IP addresses in IPv4 IP ranges",
 		&IPRanges{
 			version: IPv4,
 			ranges: []ipRange{
 				{
-					start: xIP{net.IPv4(172, 18, 0, 255).To4()},
-					end:   xIP{net.IPv4(172, 18, 1, 1).To4()},
-				},
-				{
-					start: xIP{net.IPv4(172, 18, 0, 1).To4()},
-					end:   xIP{net.IPv4(172, 18, 0, 2).To4()},
+					start: xIP{net.IPv4(172, 18, 0, 10).To4()},
+					end:   xIP{net.IPv4(172, 18, 0, 10).To4()},
 				},
 				{
 					start: xIP{net.IPv4(172, 18, 0, 2).To4()},
 					end:   xIP{net.IPv4(172, 18, 0, 3).To4()},
 				},
+				{
+					start: xIP{net.IPv4(172, 18, 0, 1).To4()},
+					end:   xIP{net.IPv4(172, 18, 0, 2).To4()},
+				},
 			},
 		},
 		[]net.IP{
-			net.IPv4(172, 18, 0, 1).To4(),
+			net.IPv4(172, 18, 0, 10).To4(),
 			net.IPv4(172, 18, 0, 2).To4(),
 			net.IPv4(172, 18, 0, 3).To4(),
-			net.IPv4(172, 18, 0, 255).To4(),
-			net.IPv4(172, 18, 1, 0).To4(),
-			net.IPv4(172, 18, 1, 1).To4(),
+			net.IPv4(172, 18, 0, 1).To4(),
+			net.IPv4(172, 18, 0, 2).To4(),
 		},
 	},
 	{
-		"Iterate through IPv6 IP ranges",
+		"Iterate through the IP addresses in IPv6 IP ranges",
 		&IPRanges{
 			version: IPv6,
 			ranges: []ipRange{
 				{
-					start: xIP{net.ParseIP("fd00::ff")},
-					end:   xIP{net.ParseIP("fd00::101")},
-				},
-				{
-					start: xIP{net.ParseIP("fd00::1")},
-					end:   xIP{net.ParseIP("fd00::2")},
+					start: xIP{net.ParseIP("fd00::a")},
+					end:   xIP{net.ParseIP("fd00::a")},
 				},
 				{
 					start: xIP{net.ParseIP("fd00::2")},
 					end:   xIP{net.ParseIP("fd00::3")},
 				},
+				{
+					start: xIP{net.ParseIP("fd00::1")},
+					end:   xIP{net.ParseIP("fd00::2")},
+				},
 			},
 		},
 		[]net.IP{
-			net.ParseIP("fd00::1"),
+			net.ParseIP("fd00::a"),
 			net.ParseIP("fd00::2"),
 			net.ParseIP("fd00::3"),
-			net.ParseIP("fd00::ff"),
-			net.ParseIP("fd00::100"),
-			net.ParseIP("fd00::101"),
+			net.ParseIP("fd00::1"),
+			net.ParseIP("fd00::2"),
 		},
 	},
 	{
@@ -74,13 +72,13 @@ var ipRangesIteratorTests = []struct {
 	},
 }
 
-func TestIPRangesIterator(t *testing.T) {
+func TestIPRangesIPIterator(t *testing.T) {
 	t.Parallel()
-	for _, test := range ipRangesIteratorTests {
+	for _, test := range ipRangesIPIteratorTests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			iter := test.ranges.Iterator()
+			iter := test.ranges.IPIterator()
 
 			var ips []net.IP
 			for {
@@ -92,7 +90,103 @@ func TestIPRangesIterator(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(ips, test.want) {
-				t.Fatalf("IPRanges(%v).Iterator() = %v, want %v", test.ranges, ips, test.want)
+				t.Fatalf("IPRanges(%v).IPIterator() = %v, want %v", test.ranges, ips, test.want)
+			}
+		})
+	}
+}
+
+var ipRangesCIDRIteratorTests = []struct {
+	name   string
+	ranges *IPRanges
+	want   []*net.IPNet
+}{
+	{
+		"Iterate through the CIDRs in IPv4 IP ranges",
+		&IPRanges{
+			version: IPv4,
+			ranges: []ipRange{
+				{
+					start: xIP{net.IPv4(172, 18, 1, 0).To4()},
+					end:   xIP{net.IPv4(172, 18, 1, 255).To4()},
+				},
+				{
+					start: xIP{net.IPv4(172, 18, 0, 1).To4()},
+					end:   xIP{net.IPv4(172, 18, 0, 3).To4()},
+				},
+			},
+		},
+		[]*net.IPNet{
+			{
+				IP:   net.IPv4(172, 18, 1, 0).To4(),
+				Mask: net.CIDRMask(24, 32),
+			},
+			{
+				IP:   net.IPv4(172, 18, 0, 1).To4(),
+				Mask: net.CIDRMask(32, 32),
+			},
+			{
+				IP:   net.IPv4(172, 18, 0, 2).To4(),
+				Mask: net.CIDRMask(31, 32),
+			},
+		},
+	},
+	{
+		"Iterate through the CIDRs in IPv6 IP ranges",
+		&IPRanges{
+			version: IPv6,
+			ranges: []ipRange{
+				{
+					start: xIP{net.ParseIP("fd00::0")},
+					end:   xIP{net.ParseIP("fd00::ffff:ffff:ffff:ffff")},
+				},
+				{
+					start: xIP{net.ParseIP("fd00::1")},
+					end:   xIP{net.ParseIP("fd00::3")},
+				},
+			},
+		},
+		[]*net.IPNet{
+			{
+				IP:   net.ParseIP("fd00::0"),
+				Mask: net.CIDRMask(64, 128),
+			},
+			{
+				IP:   net.ParseIP("fd00::1"),
+				Mask: net.CIDRMask(128, 128),
+			},
+			{
+				IP:   net.ParseIP("fd00::2"),
+				Mask: net.CIDRMask(127, 128),
+			},
+		},
+	},
+	{
+		"Empty IP ranges",
+		&IPRanges{},
+		nil,
+	},
+}
+
+func TestIPRangesCIDRIterator(t *testing.T) {
+	t.Parallel()
+	for _, test := range ipRangesCIDRIteratorTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			iter := test.ranges.CIDRIterator()
+
+			var ipNets []*net.IPNet
+			for {
+				ipNet := iter.Next()
+				if ipNet == nil {
+					break
+				}
+				ipNets = append(ipNets, ipNet)
+			}
+
+			if !reflect.DeepEqual(ipNets, test.want) {
+				t.Fatalf("IPRanges(%v).CIDRIterator() = %v, want %v", test.ranges, ipNets, test.want)
 			}
 		})
 	}

--- a/ranges.go
+++ b/ranges.go
@@ -362,30 +362,3 @@ func (rr *IPRanges) String() string {
 
 	return "[" + strings.Join(ss, " ") + "]"
 }
-
-// max returns the larger of x and y.
-func max(x, y int) int {
-	if x > y {
-		return x
-	}
-
-	return y
-}
-
-// maxXIP returns the larger xIP between x and y.
-func maxXIP(x, y xIP) xIP {
-	if x.cmp(y) > 0 {
-		return x
-	}
-
-	return y
-}
-
-// minXIP returns the smaller xIP between x and y.
-func minXIP(x, y xIP) xIP {
-	if x.cmp(y) < 0 {
-		return x
-	}
-
-	return y
-}


### PR DESCRIPTION
The implementation draws on the built-in lib `ipaddress` in Python3. Specifically, iprange can now achieve the conversion of IPRanges to *net.IPNet.

- Add a new method CIDRIterator to IPRanges for iterating through subnets(CIDR).
- Add supporting unit test and example test to CIDRIterator.
- Rename the IPRanges's method Iterator to 'IPIterator' to distinguish it from 'CIDRIterator'.
- Update godoc and README.md to describe the usage of CIDRIterator.

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>