### PR TITLE
fix: IPRanges.Size() returns its merged size

### DIFF
--- a/ranges.go
+++ b/ranges.go
@@ -151,7 +151,7 @@ func (rr1 *IPRanges) Equal(rr2 *IPRanges) bool {
 // IPRanges rr.
 func (rr *IPRanges) Size() *big.Int {
 	n := big.NewInt(0)
-	for _, r := range rr.Merge().ranges {
+	for _, r := range rr.ranges {
 		n.Add(n, r.size())
 	}
 

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -578,7 +578,7 @@ var ipRangesSizeTests = []struct {
 				},
 			},
 		},
-		big.NewInt(256),
+		big.NewInt(357),
 	},
 	{
 		"IPv6 IP range size",


### PR DESCRIPTION
Size() should not forcibly merge the source IPRanges, but rather let the caller decide whether to merge (i.e. IPRanges.Merge().Size()).

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>