### PR TITLE
test: Replace reflect.DeepEqual with cmp.Equal

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,7 +4,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -16,11 +16,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Generate coverage report
+    - name: Test
       run: |
-        go test -coverprofile cover.out ./
+        go test -race -coverprofile cover.out ./...
     
     - name: Upload coverage to Codecov
+      if: matrix.go-version == '1.20.x'
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/iiiceoo/iprange
 
-go 1.20
+go 1.18
+
+require github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2,8 +2,9 @@ package iprange
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 var ipRangesIPIteratorTests = []struct {
@@ -12,7 +13,7 @@ var ipRangesIPIteratorTests = []struct {
 	want   []net.IP
 }{
 	{
-		"Iterate through the IP addresses in IPv4 IP ranges",
+		"IPv4",
 		&IPRanges{
 			version: IPv4,
 			ranges: []ipRange{
@@ -39,7 +40,7 @@ var ipRangesIPIteratorTests = []struct {
 		},
 	},
 	{
-		"Iterate through the IP addresses in IPv6 IP ranges",
+		"IPv6",
 		&IPRanges{
 			version: IPv6,
 			ranges: []ipRange{
@@ -66,7 +67,7 @@ var ipRangesIPIteratorTests = []struct {
 		},
 	},
 	{
-		"Empty IP ranges",
+		"zero",
 		&IPRanges{},
 		nil,
 	},
@@ -89,7 +90,7 @@ func TestIPRangesIPIterator(t *testing.T) {
 				ips = append(ips, ip)
 			}
 
-			if !reflect.DeepEqual(ips, test.want) {
+			if !cmp.Equal(ips, test.want) {
 				t.Fatalf("IPRanges(%v).IPIterator() = %v, want %v", test.ranges, ips, test.want)
 			}
 		})
@@ -102,7 +103,7 @@ var ipRangesCIDRIteratorTests = []struct {
 	want   []*net.IPNet
 }{
 	{
-		"Iterate through the CIDRs in IPv4 IP ranges",
+		"IPv4",
 		&IPRanges{
 			version: IPv4,
 			ranges: []ipRange{
@@ -132,7 +133,7 @@ var ipRangesCIDRIteratorTests = []struct {
 		},
 	},
 	{
-		"Iterate through the CIDRs in IPv6 IP ranges",
+		"IPv6",
 		&IPRanges{
 			version: IPv6,
 			ranges: []ipRange{
@@ -162,7 +163,7 @@ var ipRangesCIDRIteratorTests = []struct {
 		},
 	},
 	{
-		"Empty IP ranges",
+		"zero",
 		&IPRanges{},
 		nil,
 	},
@@ -185,7 +186,7 @@ func TestIPRangesCIDRIterator(t *testing.T) {
 				ipNets = append(ipNets, ipNet)
 			}
 
-			if !reflect.DeepEqual(ipNets, test.want) {
+			if !cmp.Equal(ipNets, test.want) {
 				t.Fatalf("IPRanges(%v).CIDRIterator() = %v, want %v", test.ranges, ipNets, test.want)
 			}
 		})


### PR DESCRIPTION
- Downgrade Go version to 1.18.
- Use Google/go-cmp to complete testing assertions.
- Simplifiy the name of subtests.
- Add Go 1.18.x to 1.20.x in the matrix.go-version of CI.

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>